### PR TITLE
The Statistical Recurrent Unit paper added.

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,8 @@ Please feel free to [pull requests](https://github.com/kjw0612/awesome-rnn/pulls
   * Oriol Vinyals, Samy Bengio, Manjunath Kudlur, "Order Matters: Sequence to sequence for sets", ICLR 2016.
 * Hierarchical Recurrent Neural Networks [[Paper](http://arxiv.org/abs/1609.01704)]
   * Junyoung Chung, Sungjin Ahn, Yoshua Bengio, "Hierarchical Multiscale Recurrent Neural Networks", arXiv:1609.01704
-
+* The Statistical Recurrent Unit [[Paper](https://arxiv.org/pdf/1703.00381.pdf)]
+  * Junier B. Oliva, Barnabas Poczos,Jeff Schneider, *The Statistical Recurrent Unit*, arxiv:1703.00381 / ICML 2017
 #### Memory
 
 * LSTM [[Paper](http://deeplearning.cs.cmu.edu/pdfs/Hochreiter97_lstm.pdf)]


### PR DESCRIPTION
New paper to appear at ICML 2017, "The Statistical Recurrent Unit" added to the readme file.